### PR TITLE
Improve the quality of 'What should I do next?' recommendations

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.2.3
+erlang 25.3.2.8
 elixir 1.14.3-otp-25

--- a/lib/ex_assignment/services/todo_recommender.ex
+++ b/lib/ex_assignment/services/todo_recommender.ex
@@ -1,0 +1,21 @@
+defmodule ExAssignment.Services.TodoRecommender do
+  @moduledoc """
+  Module implementing the todo recommender service.
+    This service recommends a random task based on the tasks priority. Tasks with lower priority have a high probability of being picked.
+
+  The recommender makes use of a WeightBasedSampler service to randomly chose a
+    task based on a tasks priority.
+  """
+
+  @doc """
+  Returns the next todo that is recommended to be done by the system.
+
+  ASSIGNMENT: ...
+  """
+  def recommend(todos) do
+    case todos do
+      [] -> nil
+      todos -> todos |> Enum.take_random(1) |> List.first()
+    end
+  end
+end

--- a/lib/ex_assignment/services/todo_recommender.ex
+++ b/lib/ex_assignment/services/todo_recommender.ex
@@ -1,21 +1,49 @@
 defmodule ExAssignment.Services.TodoRecommender do
   @moduledoc """
   Module implementing the todo recommender service.
-    This service recommends a random task based on the tasks priority. Tasks with lower priority have a high probability of being picked.
+    This service recommends a random task based on the task's priority. Tasks with lower priority have a high probability of being picked.
 
   The recommender makes use of a WeightBasedSampler service to randomly chose a
-    task based on a tasks priority.
+  task based on a task's priority.
+
+  Task recommendation works as follows.
+    1. Reject done todos
+    2. Compute the reciprocals of the priorities of open todos. This is to ensure that lower priorities
+       have a higher probability.
+    3. Pass the todos with their inverted priorities to a weight based sampler service.
+
+  E.g. The following tasks have the following inverted_priorities:
+    todos = %{ "Prepare lunch" => 20, "Water flowers" => 50, "Shop groceries" => 60, "Buy new flower pots" => 130 }
+    todos_with_inverted_priorities = %{ "Prepare lunch" => 0.05, "Water flowers" => 0.02, "Shop groceries" => 0.0167, "Buy new flower pots" => 0.0077 }
   """
 
-  @doc """
-  Returns the next todo that is recommended to be done by the system.
+  # Since 0 is a valid priority, we add a small delta to avoid division by zero.
+  @zero 0.0001
 
-  ASSIGNMENT: ...
+  @doc """
+  Returns the next todo recommended by the system.
+
+  The result is a single recommended tasks if the argument list contains at least one open todo or nil.
   """
   def recommend(todos) do
     case todos do
       [] -> nil
-      todos -> todos |> Enum.take_random(1) |> List.first()
+      todos -> todos
+        |> Enum.reject(fn todo -> todo.done end)
+        |> Enum.map(fn todo -> %{todo | inverse_priority: compute_inverse_priority(todo.priority)} end)
+        |> Enum.take_random(1)
+        |> List.first()
+    end
+  end
+
+  # Possibilities of handling 0 priority
+  # 1. Reject the task?
+  # 2. Replace with a number close to 0? ✓
+  # 3. Raise an error
+  defp compute_inverse_priority(priority) do
+    case priority do
+      0 -> @zero
+      _ -> 1.0 / priority
     end
   end
 end

--- a/lib/ex_assignment/services/todo_recommender.ex
+++ b/lib/ex_assignment/services/todo_recommender.ex
@@ -34,7 +34,7 @@ defmodule ExAssignment.Services.TodoRecommender do
         |> Enum.reject(fn todo -> todo.done end)
         |> Enum.map(fn todo -> %{todo | inverse_priority: compute_inverse_priority(todo.priority)} end)
         |> Enum.reduce(%{}, fn todo, acc -> Map.put(acc, todo, todo.inverse_priority) end)
-        |> Sampler.sample
+        |> Sampler.sample()
     end
   end
 

--- a/lib/ex_assignment/services/weight_based_sampler.ex
+++ b/lib/ex_assignment/services/weight_based_sampler.ex
@@ -1,0 +1,45 @@
+defmodule ExAssignment.Services.WeightBasedSampler do
+  @moduledoc """
+  A sampler that takes into consideration the weights of items when randomly selecting an item.
+  Since the sampling is based on relative weights, we consider a weight of zero as invalid input.
+
+  The sampling algorithm is based on the following articles.
+  https://elixirforum.com/t/weight-based-random-sampling/23345/6
+  https://gist.github.com/O-I/3e0654509dd8057b539a
+  https://hexdocs.pm/weighted_random/WeightedRandom.html
+
+  We chose an elixir implementation of the Ruby version.
+  """
+
+  @doc """
+  Accepts a map of items with their corresponding weights
+    %{walk: 0.5, shop: 0.5, work: 0.1, gym: 0.2}
+
+
+  Returns an item from the list selected based on the weights. Returns nil if provided with invalid input.
+  The sampler is not responsible for inverting the weights. Callers should ensure that the weights are already inverted.
+  """
+  def sample(items) when map_size(items) == 0 do
+    nil
+  end
+
+  def sample(items) do
+    items
+    |> normalize_probabilities()
+    |> pick_random_by_weight()
+    |> elem(0)
+  end
+
+  @doc """
+    Normalizes the relative weights to probabilities. The sum of the normalized weights always equals 1
+    %{walk: 0.3846}, {shop: 0.3846}, {work: 0.0769}, {gym: 0.1538}
+  """
+  defp normalize_probabilities(items) do
+    sum_of_weights = Enum.reduce(items, 0, fn {_key, value}, acc -> acc + value end)
+    Enum.reduce(items, %{}, fn {key, value}, acc -> Map.put(acc, key, value / sum_of_weights) end)
+  end
+
+  defp pick_random_by_weight(items) do
+    Enum.max_by(items, fn {_key, weight} -> :rand.uniform() * (1 / weight) end)
+  end
+end

--- a/lib/ex_assignment/services/weight_based_sampler.ex
+++ b/lib/ex_assignment/services/weight_based_sampler.ex
@@ -34,12 +34,14 @@ defmodule ExAssignment.Services.WeightBasedSampler do
     Normalizes the relative weights to probabilities. The sum of the normalized weights always equals 1
     %{walk: 0.3846}, {shop: 0.3846}, {work: 0.0769}, {gym: 0.1538}
   """
-  defp normalize_probabilities(items) do
+
+  # This function is made public so it can be tested
+  def normalize_probabilities(items) do
     sum_of_weights = Enum.reduce(items, 0, fn {_key, value}, acc -> acc + value end)
     Enum.reduce(items, %{}, fn {key, value}, acc -> Map.put(acc, key, value / sum_of_weights) end)
   end
 
   defp pick_random_by_weight(items) do
-    Enum.max_by(items, fn {_key, weight} -> :rand.uniform() * (1 / weight) end)
+    Enum.max_by(items, fn {_key, weight} -> :rand.uniform() ** (1 / weight) end)
   end
 end

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -40,19 +40,6 @@ defmodule ExAssignment.Todos do
   end
 
   @doc """
-  Returns the next todo that is recommended to be done by the system.
-
-  ASSIGNMENT: ...
-  """
-  def get_recommended() do
-    list_todos(:open)
-    |> case do
-      [] -> nil
-      todos -> Enum.take_random(todos, 1) |> List.first()
-    end
-  end
-
-  @doc """
   Gets a single todo.
 
   Raises `Ecto.NoResultsError` if the Todo does not exist.

--- a/lib/ex_assignment/todos/todo.ex
+++ b/lib/ex_assignment/todos/todo.ex
@@ -5,6 +5,7 @@ defmodule ExAssignment.Todos.Todo do
   schema "todos" do
     field(:done, :boolean, default: false)
     field(:priority, :integer)
+    field(:inverse_priority, :integer, virtual: true)
     field(:title, :string)
 
     timestamps()

--- a/lib/ex_assignment/todos/todo.ex
+++ b/lib/ex_assignment/todos/todo.ex
@@ -16,5 +16,6 @@ defmodule ExAssignment.Todos.Todo do
     todo
     |> cast(attrs, [:title, :priority, :done])
     |> validate_required([:title, :priority, :done])
+    |> validate_number(:priority, greater_than_or_equal_to: 0)
   end
 end

--- a/lib/ex_assignment_web/controllers/todo_controller.ex
+++ b/lib/ex_assignment_web/controllers/todo_controller.ex
@@ -5,9 +5,6 @@ defmodule ExAssignmentWeb.TodoController do
   alias ExAssignment.Todos
   alias ExAssignment.Todos.Todo
 
-  alias ExAssignment.Services.TodoRecommender, as: Recommender
-
-
   def index(conn, _params) do
     open_todos = Todos.list_todos(:open)
     done_todos = Todos.list_todos(:done)

--- a/lib/ex_assignment_web/controllers/todo_controller.ex
+++ b/lib/ex_assignment_web/controllers/todo_controller.ex
@@ -1,13 +1,17 @@
 defmodule ExAssignmentWeb.TodoController do
   use ExAssignmentWeb, :controller
 
+  alias ExAssignment.Services.TodoRecommender, as: Recommender
   alias ExAssignment.Todos
   alias ExAssignment.Todos.Todo
+
+  alias ExAssignment.Services.TodoRecommender, as: Recommender
+
 
   def index(conn, _params) do
     open_todos = Todos.list_todos(:open)
     done_todos = Todos.list_todos(:done)
-    recommended_todo = Todos.get_recommended()
+    recommended_todo = open_todos |> Enum.concat(done_todos) |> Recommender.recommend()
 
     render(conn, :index,
       open_todos: open_todos,

--- a/test/ex_assignment/services/todo_recommender_test.exs
+++ b/test/ex_assignment/services/todo_recommender_test.exs
@@ -1,0 +1,23 @@
+defmodule ExAssignment.Services.TodoRecommenderTest do
+  use ExAssignment.DataCase
+
+  alias ExAssignment.Services.TodoRecommender, as: Recommender
+
+  describe "recommend" do
+    import ExAssignment.TodosFixtures
+
+    @closed_attrs %{done: true}
+    @open_attrs %{done: false}
+    @zero_priority_attrs %{priority: 0, done: false}
+
+    test "returns nil when supplied with an empty list of todos" do
+      todos = []
+      assert Recommender.recommend(todos) == nil
+    end
+
+    test "returns nil when supplied with a list without any open todos" do
+      todos = [todo_fixture(@closed_attrs), todo_fixture(@closed_attrs)]
+      assert Recommender.recommend(todos) == nil
+    end
+  end
+end

--- a/test/ex_assignment/services/todo_recommender_test.exs
+++ b/test/ex_assignment/services/todo_recommender_test.exs
@@ -19,5 +19,43 @@ defmodule ExAssignment.Services.TodoRecommenderTest do
       todos = [todo_fixture(@closed_attrs), todo_fixture(@closed_attrs)]
       assert Recommender.recommend(todos) == nil
     end
+
+    test "returns the single open todo when supplied with a list having only one open todo" do
+      open_todo = @open_attrs
+        |> todo_fixture()
+        |> assign_inverted_priority()
+
+      closed_todos = [todo_fixture(@closed_attrs), todo_fixture(@closed_attrs)]
+
+      recommended_todo = closed_todos
+        |> Enum.concat([open_todo])
+        |> Recommender.recommend()
+
+      assert recommended_todo == open_todo
+    end
+
+    test "does not return closed todos" do
+      open_todos = Enum.map([todo_fixture(@open_attrs), todo_fixture(@open_attrs)], fn todo -> assign_inverted_priority(todo) end)
+      closed_todos = [todo_fixture(@closed_attrs), todo_fixture(@closed_attrs)]
+
+      recommended_todo = closed_todos
+        |> Enum.concat(open_todos)
+        |> Recommender.recommend()
+
+      assert Enum.member?(open_todos, recommended_todo)
+      refute Enum.member?(closed_todos, recommended_todo)
+    end
+
+    test "does not error with zero priority" do
+      todo = @zero_priority_attrs
+        |> todo_fixture()
+        |> assign_inverted_priority()
+
+      assert Recommender.recommend([todo]) == todo
+    end
+  end
+
+  defp assign_inverted_priority(todo) do
+    %{todo | inverse_priority: Recommender.compute_inverse_priority(todo.priority)}
   end
 end

--- a/test/ex_assignment/services/todo_recommender_test.exs
+++ b/test/ex_assignment/services/todo_recommender_test.exs
@@ -53,6 +53,23 @@ defmodule ExAssignment.Services.TodoRecommenderTest do
 
       assert Recommender.recommend([todo]) == todo
     end
+
+    test "tasks with lower priorities are more likely to be picked" do
+      todos = for n <- 1..10 do
+        todo_fixture(%{priority: n * 10, done: false})
+      end
+
+      frequencies = Stream.repeatedly(fn -> Recommender.recommend(todos) end)
+                    |> Enum.take(100)
+                    |> Enum.frequencies()
+                    |> Enum.to_list()
+
+      first_todo = frequencies |> List.first
+      last_todo = frequencies |> List.last
+
+      assert elem(first_todo,0).id < elem(last_todo,0).id
+      assert elem(first_todo,1) > elem(last_todo,1)
+    end
   end
 
   defp assign_inverted_priority(todo) do

--- a/test/ex_assignment/services/weight_based_sampler_test.exs
+++ b/test/ex_assignment/services/weight_based_sampler_test.exs
@@ -1,0 +1,63 @@
+defmodule ExAssignment.Services.WeightBasedSamplerTest do
+  use ExUnit.Case
+
+  alias ExAssignment.Services.WeightBasedSampler, as: Sampler
+
+  describe "normalize_probabilities" do
+    test "the sum of probabilities should be one" do
+      items = %{walk: 5, shop: 5, work: 0.1, gym: 200}
+
+      assert items
+             |> Sampler.normalize_probabilities()
+             |> Enum.reduce(0, fn {_key, value}, acc -> acc + value end) == 1
+    end
+
+    test "single item map has a probability of one" do
+      items = %{walk: 100}
+
+      assert Sampler.normalize_probabilities(items).walk == 1
+    end
+
+    test "returns an empty map when provided an empty map" do
+      items = %{}
+
+      assert Sampler.normalize_probabilities(items) == %{}
+    end
+  end
+
+  describe "sample" do
+    test "high weight items are more likely to be picked" do
+      items = %{shop: 200, work: 20}
+
+      frequencies = Stream.repeatedly(fn -> Sampler.sample(items) end)
+        |> Enum.take(1000)
+        |> Enum.frequencies()
+
+      assert frequencies.shop > frequencies.work
+    end
+
+    test "it respects the relative weights" do
+      items = %{shop: 200, work: 2}
+
+      frequencies =
+        fn -> Sampler.sample(items) end
+        |> Stream.repeatedly()
+        |> Enum.take(1000)
+        |> Enum.frequencies()
+
+      assert frequencies.shop > frequencies.work * 50
+      # assert_in_delta(frequencies.shop, frequencies.work * 100, 500)
+    end
+
+    test "single item map is always picked" do
+      items = %{walk: 100}
+      runs = 100
+
+      frequencies = Stream.repeatedly(fn -> Sampler.sample(items) end)
+      |> Enum.take(runs)
+      |> Enum.frequencies()
+
+      assert frequencies == %{walk: runs}
+    end
+  end
+end

--- a/test/ex_assignment/services/weight_based_sampler_test.exs
+++ b/test/ex_assignment/services/weight_based_sampler_test.exs
@@ -39,9 +39,7 @@ defmodule ExAssignment.Services.WeightBasedSamplerTest do
     test "it respects the relative weights" do
       items = %{shop: 200, work: 2}
 
-      frequencies =
-        fn -> Sampler.sample(items) end
-        |> Stream.repeatedly()
+      frequencies = Stream.repeatedly(fn -> Sampler.sample(items) end)
         |> Enum.take(1000)
         |> Enum.frequencies()
 
@@ -51,13 +49,26 @@ defmodule ExAssignment.Services.WeightBasedSamplerTest do
 
     test "single item map is always picked" do
       items = %{walk: 100}
-      runs = 100
 
       frequencies = Stream.repeatedly(fn -> Sampler.sample(items) end)
-      |> Enum.take(runs)
-      |> Enum.frequencies()
+        |> Enum.take(100)
+        |> Enum.frequencies()
 
-      assert frequencies == %{walk: runs}
+      assert frequencies == %{walk: 100}
+    end
+
+    test "correctly handles invalid input" do
+      non_map_input = [walk: 5, shop: 5, work: 0.1, gym: 200]
+      empty_input = %{}
+      zero_weight = %{walk: 5, shop: 5, work: 0.1, gym: 0}
+      negative_weight = %{walk: 5, shop: 5, work: 0.1, gym: -200}
+      non_numeric_weight = %{walk: ~c"5", shop: :abcd, work: 0.1, gym: 200}
+
+      assert Sampler.sample(non_map_input) == nil
+      assert Sampler.sample(empty_input) == nil
+      assert Sampler.sample(zero_weight) == nil
+      assert Sampler.sample(negative_weight) == nil
+      assert Sampler.sample(non_numeric_weight) == nil
     end
   end
 end

--- a/test/ex_assignment/todos_test.exs
+++ b/test/ex_assignment/todos_test.exs
@@ -9,6 +9,7 @@ defmodule ExAssignment.TodosTest do
     import ExAssignment.TodosFixtures
 
     @invalid_attrs %{done: nil, priority: nil, title: nil}
+    @invalid_priority %{title: "A hard task", done: false, priority: -42}
 
     test "list_todos/0 returns all todos" do
       todo = todo_fixture()
@@ -31,6 +32,17 @@ defmodule ExAssignment.TodosTest do
 
     test "create_todo/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Todos.create_todo(@invalid_attrs)
+    end
+
+    test "create_todo/1 with invalid priority returns error changeset" do
+      changeset = Todos.create_todo(@invalid_priority)
+
+      assert {:error, %Ecto.Changeset{}} = changeset
+      assert elem(changeset, 1).errors == [
+               priority:
+                 {"must be greater than or equal to %{number}",
+                  [validation: :number, kind: :greater_than_or_equal_to, number: 0]}
+             ]
     end
 
     test "update_todo/2 with valid data updates the todo" do


### PR DESCRIPTION
Currently, the recommended todo is randomly selected ignoring the priorities.

This PR fixes this by introducing a WeightedRandomSampler that takes into consideration the weights of items when randomly selecting an item. The  WeightedRandomSampler first normalizes the probabilities leading to a situation where the sum of the probabilities of all items equals one. We then use the algorithm defined in this [article](https://gist.github.com/O-I/3e0654509dd8057b539a) to select an item from the provided items. Since the sampling is based on relative weights, we consider a weight of zero as invalid input. 

The WeightedRandomSampler is used by a Recommender service to recommend a todo. The Recommender computes the reciprocal of a todos priority as its determining priority. Tasks with lower priority thus have a higher probability of being picked.

There are many ways of handling todos with a priority of zero and we chose to replace zero with a number close to zero. The other options are shown in the comments of the Recommender service.